### PR TITLE
Fix the default cfml extensions in the vs code settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
                     "type": "array",
                     "default": [
                         ".cfm",
-                        ".box.cfm"
+                        ".box.cfm",
+                        ".cfc"
                     ],
                     "items": {
                         "type": "string"


### PR DESCRIPTION
Add .cfc to the vs code settings default extensions